### PR TITLE
primary key `id` columns are implicitly added

### DIFF
--- a/db/migrate/20141024163003_create_docker_registries.rb
+++ b/db/migrate/20141024163003_create_docker_registries.rb
@@ -3,13 +3,11 @@ class CreateDockerRegistries < ActiveRecord::Migration
     create_table :docker_registries do |t|
       t.string :url
       t.string :name
-      t.integer :id
       t.string :description
       t.timestamps
     end
 
     create_table :docker_image_docker_registries do |t|
-      t.integer :id
       t.integer :docker_registry_id
       t.integer :docker_image_id
     end


### PR DESCRIPTION
This commit is to fix [1] during migrations.

More info on rails4 active_record migrations can be found here [2].

[1] `you can't redefine the primary key column 'id'. To define a custom
primary key, pass { id: false } to create_table.`

[2] http://edgeguides.rubyonrails.org/active_record_migrations.html
